### PR TITLE
fix<mysql>: generate a correct connection string

### DIFF
--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -84,10 +84,11 @@ func buildConnectionString(databaseName string) string {
 			cs = fmt.Sprintf("%s@", cs)
 		}
 		if opts.Host != "" {
-			cs = fmt.Sprintf("%s%s", cs, opts.Host)
+			cs = fmt.Sprintf("%stcp(%s", cs, opts.Host)
 			if opts.Port != "" {
 				cs = fmt.Sprintf("%s:%s", cs, opts.Port)
 			}
+			cs += ")"
 		}
 		cs = fmt.Sprintf("%s/", cs)
 		if databaseName != "" {

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -1,0 +1,43 @@
+// +build !skip_mysql
+
+package mysql
+
+import (
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func Test_buildConnectionString(t *testing.T) {
+	type args struct {
+		databaseName string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		opts    mysqlOpts
+		setOpts bool
+		want    string
+	}{
+		{args: args{databaseName: "ssetest"}, setOpts: true, want: "tcp(192.0.2.0)/ssetest",
+			opts: mysqlOpts{Host: "192.0.2.0", Database: "ssetest"},
+		},
+		{args: args{databaseName: "ssetest"}, setOpts: true, want: "/ssetest",
+			opts: mysqlOpts{Port: "3307", Database: "ssetest"},
+		},
+		{args: args{databaseName: "ssetest"}, setOpts: true, want: "sseuser:passwd@tcp(192.0.2.0)/ssetest",
+			opts: mysqlOpts{Host: "192.0.2.0", Database: "ssetest", User: "sseuser", Password: "passwd"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setOpts {
+				opts = &tt.opts
+			}
+			if got := buildConnectionString(tt.args.databaseName); got != tt.want {
+				t.Errorf("buildConnectionString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The generated connection string must follow the format
[username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]

Before this change it will generate an error if mysql-host is provided.
```
go test sse_test.go -run 'Test_CheckConnection' -driver mysql -mysql-database ssetest -mysql-host 192.168.239.128 -mysql-user ssetestusr -mysql-password ssetestusrpass
2019/11/13 11:50:29 mysql is the driver
2019/11/13 11:50:29 Connecting to mysql db
2019/11/13 11:50:29 Connected.
--- FAIL: Test_CheckConnection (0.00s)
    sse_test.go:68: default addr for network '192.168.239.128' unknown
FAIL
FAIL    command-line-arguments  0.165s
FAIL
```